### PR TITLE
resolve bignum issue using pure javascript method

### DIFF
--- a/lib/packer/b.js
+++ b/lib/packer/b.js
@@ -7,7 +7,7 @@ exports.unpack = function(msg, packager) {
 
 	do {
 		chunk = msg.substring(0, packager.length);
-		chunkBitmap = bignum(chunk, 16).toString(2);
+		chunkBitmap = parseInt(chunk, 16).toString(2);
 		while (chunkBitmap.length < (packager.length * 4)) {
 			chunkBitmap = '0' + chunkBitmap;
 		}


### PR DESCRIPTION
as @brookqin mentioned at #3 , bignum do not support base 2.
So I changed `bignum(chunk, 16).toString(2);` to `parseInt(chunk, 16).toString(2);`.
And there's no error occurred now.
Please check.
